### PR TITLE
Update Stacksize.cfg

### DIFF
--- a/config/Stacksize.cfg
+++ b/config/Stacksize.cfg
@@ -45,6 +45,25 @@ settings {
         record_ward
         record_11
         record_wait
+        ironchest:iron_gold_chest_upgrade
+        ironchest:gold_diamond_chest_upgrade
+        ironchest:copper_silver_chest_upgrade
+        ironchest:silver_gold_chest_upgrade
+        ironchest:copper_iron_chest_upgrade
+        ironchest:diamond_crystal_chest_upgrade
+        ironchest:wood_iron_chest_upgrade
+        ironchest:wood_copper_chest_upgrade
+        ironchest:diamond_obsidian_chest_upgrade
+        ironchest:iron_gold_shulker_upgrade
+        ironchest:gold_diamond_shulker_upgrade
+        ironchest:copper_silver_shulker_upgrade
+        ironchest:silver_gold_shulker_upgrade
+        ironchest:copper_iron_shulker_upgrade
+        ironchest:diamond_crystal_shulker_upgrade
+        ironchest:Vanilla_iron_shulker_upgrade
+        ironchest:Vanilla_copper_shulker_upgrade
+        ironchest:diamond_obsidian_shulker_upgrade
+        quark:witch_hat
      >
     I:"New Stack Size"=64
     S:"Unique Stacksize Item Names" <


### PR DESCRIPTION
厳密にはほしいもっもではないが、IronChestの容量拡張アイテムをスタック可能にしてほしい。
理由：たくさん作ろうと思ったときにインベントリを圧迫して不便なため。
 -by ksrg