### PR TITLE
docs: update Bauble's license

### DIFF
--- a/docs/mods/Baubles.md
+++ b/docs/mods/Baubles.md
@@ -3,7 +3,7 @@
 - もっも名: Baubles
 - もっものバージョン: 1.12-1.5.2
 - DLリンク: https://www.curseforge.com/minecraft/mc-mods/baubles/files/2518667
-- LICENCE: [Custom License](https://www.curseforge.com/minecraft/mc-mods/baubles/files/2518667)
+- LICENCE: [CC BY-NC-SA 3.0](https://www.curseforge.com/project/227083/license)
 - Project ID: 1.12-1.5.2
 - 前提mod: N/A
 - 依存mod: baublelicious


### PR DESCRIPTION
CC BY-NC-SA 3.0 was not included CurseForge's license template list, and it's not actually a kind of custom license.